### PR TITLE
ci: fix CI workflow failures blocking open dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-validation.yml
+++ b/.github/workflows/dependabot-auto-validation.yml
@@ -142,7 +142,7 @@ jobs:
         uses: hashicorp/setup-terraform@v4
 
       - name: Install tofu
-        uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668493e69f103 # v1.0.5
+        uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # v1.0.5
         with:
           tofu_version: "1.9.0"
 
@@ -216,7 +216,9 @@ jobs:
 
       - name: Install MkDocs dependencies
         run: |
-          pip install --only-binary :all: -r docs/requirements.txt
+          # jsmin and csscompressor (transitive deps of mkdocs-minify-plugin) only ship a
+          # source distribution on PyPI, so they must be excluded from --only-binary.
+          pip install --only-binary :all: --no-binary jsmin,csscompressor -r docs/requirements.txt
 
       - name: Validate MkDocs build
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,10 @@ concurrency:
 
 jobs:
   update-terraform-docs:
-    if: github.event_name == 'pull_request'
+    # Dependabot-triggered pull_request events receive a read-only GITHUB_TOKEN with no
+    # access to secrets, so git-push would fail. Skip this job for Dependabot PRs;
+    # dependabot-auto-validation.yml handles docs validation for those PRs instead.
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/reusable-terraform-docs.yml
     permissions:
       contents: write
@@ -79,7 +82,9 @@ jobs:
 
       - name: Install MkDocs dependencies
         run: |
-          pip install --only-binary :all: -r docs/requirements.txt
+          # jsmin and csscompressor (transitive deps of mkdocs-minify-plugin) only ship a
+          # source distribution on PyPI, so they must be excluded from --only-binary.
+          pip install --only-binary :all: --no-binary jsmin,csscompressor -r docs/requirements.txt
 
       - name: Apply Python SSL fixes
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.tfstate
 *.tfstate.*
 .terraform/
-.terraform.lock.hcl
+# .terraform.lock.hcl is intentionally tracked to pin provider versions for CI
 crash.log
 *.backup
 *.tfvars

--- a/examples/minimal/.terraform.lock.hcl
+++ b/examples/minimal/.terraform.lock.hcl
@@ -1,6 +1,30 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/github" {
+  version = "6.13.0"
+  hashes = [
+    "h1:2kD+4leuV8tBBXv+EPeehmfW6cDhIzVki61OXsGCtRI=",
+    "h1:Mug81HyUTKKMngXMOtBxuQ8ge3dVnzt9tGcF9SxLcVE=",
+    "h1:YS8951MRtP4YNs2CNsDfqE7Mr9tDz/Y7xDSo18zyCkQ=",
+    "h1:y0Sujto8gttV86innNp/LTMzq7CqsFpBs7XKH8AlMl4=",
+    "zh:0ab29fc21699f34345cf0bbbe44745fd1b143b7c73b410c1dc4abe05ffad0a84",
+    "zh:1aed10d06755d420bb3a893bf548ab2932297a9d094c04c5a8501e949ca186ed",
+    "zh:2a6a11c21eae408055f45b9533c07afd2e845f6d496fd1b645aec2e873012103",
+    "zh:5dd05dee677f6ebdbed00cbb1b9be444ab2d1062d345cbc9ec50a47cb41b8622",
+    "zh:6b757d034831243d67ddda869eac4368cef539848bd97511f4d68f1aa38a9c88",
+    "zh:947c9b5b238f0364c57a705beabd24d3eea3159a6f3a24c07e3fbb13657ffae0",
+    "zh:a676549a98164b61630658cbeb6c17820331ca04a049dc9b5095996a0c31ffbe",
+    "zh:a8a81b7fe41dd61eb6a6fa5e08a4dd9ee070e862868252a7fd4cfce30364efee",
+    "zh:c26a9bca4865665084e7f59b1402d7aff34ee63a418d7401a0658fa280cad4d4",
+    "zh:c638d8d0762e62ea188f86302954ef4c92803f2160f0a45fca0cd13974bd3725",
+    "zh:e739a0b7e81ca816944a18a38e679f4015edf8be7ac319815cdea865ba7727d7",
+    "zh:ec099487ea3de8999c84b3b791e242d728461e51fe344832b37bd8d521201c77",
+    "zh:f016ff9e2daab5b88185cec0795213049d105439ffd585d3309a714514ccae13",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.3.0"
   constraints = "~> 3.2"


### PR DESCRIPTION
Fixes the root causes making every open Dependabot PR fail CI (tracked in #567):

1. **Terraform Validation / validate-examples / terraform-validation-1-5/1-6/1-7/latest** all failing with `Provider dependency changes detected... lock file is read-only` — `.terraform.lock.hcl` was gitignored so `-lockfile=readonly` had nothing to read. main already dropped `-lockfile=readonly`; this branch additionally commits the lock files for the root module and `examples/minimal` and un-ignores them for reproducible provider pinning.
2. **go-tests** failing at job setup with `Unable to resolve action opentofu/setup-opentofu@...493e69f103` — the pinned commit SHA had a typo. Corrected to the real SHA for v1.0.5.
3. **docs-validation** failing on `pip install --only-binary :all: -r docs/requirements.txt` with `No matching distribution found for jsmin` — `jsmin` and `csscompressor` (transitive deps of `mkdocs-minify-plugin`) only publish sdists on PyPI. Added `--no-binary jsmin,csscompressor` exceptions.
4. **update-terraform-docs** failing with `Input required and not supplied: token` — Dependabot-triggered `pull_request` events get a read-only `GITHUB_TOKEN` with no secret access. Skip this job when `github.actor == 'dependabot[bot]'`.

Verified locally: `terraform init` + `terraform validate` succeed for both the root module and `examples/minimal`; `go test` passes; `pip install --only-binary :all: --no-binary jsmin,csscompressor -r docs/requirements.txt` installs cleanly in a fresh venv (Python 3.13).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>