### PR TITLE
ci: fix Terraform 1.6.0 signature verification failure and dependabot docs skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
       token: ${{ github.token }}
 
   terraform-validation-1-6:
-    name: "Terraform Validation (1.6.0)"
+    name: "Terraform Validation (1.6.6)"
     uses: ./.github/workflows/reusable-terraform-validation.yml
     permissions:
       contents: read
       security-events: write
     with:
-      terraform_version: "1.6.0"
+      terraform_version: "1.6.6"
       working_directory: "."
       backend: false
     secrets:
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
-          terraform_version: "1.6.0"
+          terraform_version: "1.6.6"
       
       - name: Terraform init
         run: terraform init -input=false -upgrade=false -backend=false
@@ -182,8 +182,8 @@ jobs:
 
       - name: Install Terraform
         run: |
-          wget https://releases.hashicorp.com/terraform/1.6.0/terraform_1.6.0_linux_amd64.zip
-          unzip terraform_1.6.0_linux_amd64.zip
+          wget https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_linux_amd64.zip
+          unzip terraform_1.6.6_linux_amd64.zip
           sudo mv terraform /usr/local/bin/
           terraform version
 
@@ -209,7 +209,7 @@ jobs:
           echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
           echo "| --- | ------ |" >> $GITHUB_STEP_SUMMARY
           echo "| Terraform Validation (1.5.0) | ${{ needs.terraform-validation-1-5.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Terraform Validation (1.6.0) | ${{ needs.terraform-validation-1-6.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Terraform Validation (1.6.6) | ${{ needs.terraform-validation-1-6.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Additional Terraform Checks | ${{ needs.terraform-additional-checks.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Security Scanning | ${{ needs.security-scan.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Terraform Docs | ${{ needs.terraform-docs.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/dependabot-auto-validation.yml
+++ b/.github/workflows/dependabot-auto-validation.yml
@@ -52,7 +52,7 @@ jobs:
       contents: read
       security-events: write
     with:
-      terraform_version: "1.6.0"
+      terraform_version: "1.6.6"
       working_directory: "."
     secrets:
       token: ${{ github.token }}
@@ -301,5 +301,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '❌ **Dependabot PR Validation Failed**\n\nOne or more validation checks failed. Please review the failed checks and fix any issues before merging.\n\n- Terraform Validation 1.5.0: ${{ needs.terraform-validation-1-5.result }}\n- Terraform Validation 1.6.0: ${{ needs.terraform-validation-1-6.result }}\n- Terraform Validation 1.7.0: ${{ needs.terraform-validation-1-7.result }}\n- Terraform Validation Latest: ${{ needs.terraform-validation-latest.result }}\n- Example Validation: ${{ needs.validate-examples.result }}\n- Go Tests: ${{ needs.go-tests.result }}\n- Security Scan: ${{ needs.security-scan.result }}\n- Documentation: ${{ needs.docs-validation.result }}'
+              body: '❌ **Dependabot PR Validation Failed**\n\nOne or more validation checks failed. Please review the failed checks and fix any issues before merging.\n\n- Terraform Validation 1.5.0: ${{ needs.terraform-validation-1-5.result }}\n- Terraform Validation 1.6.6: ${{ needs.terraform-validation-1-6.result }}\n- Terraform Validation 1.7.0: ${{ needs.terraform-validation-1-7.result }}\n- Terraform Validation Latest: ${{ needs.terraform-validation-latest.result }}\n- Example Validation: ${{ needs.validate-examples.result }}\n- Go Tests: ${{ needs.go-tests.result }}\n- Security Scan: ${{ needs.security-scan.result }}\n- Documentation: ${{ needs.docs-validation.result }}'
             })

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,9 @@ jobs:
     # Dependabot-triggered pull_request events receive a read-only GITHUB_TOKEN with no
     # access to secrets, so git-push would fail. Skip this job for Dependabot PRs;
     # dependabot-auto-validation.yml handles docs validation for those PRs instead.
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    # Check the PR author (not github.actor) so this also skips correctly when a
+    # non-dependabot actor triggers the event (e.g. via the "update branch" API).
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
     uses: ./.github/workflows/reusable-terraform-docs.yml
     permissions:
       contents: write


### PR DESCRIPTION
Fixes #567.

Follow-up to previously merged CI fix PR. Fixes two remaining CI failures observed after propagating the first fix to open Dependabot PRs:

1. **terraform-validation-1-6** consistently failing with `Error while installing hashicorp/null v3.3.0: error checking signature: openpgp: key expired`. Terraform 1.6.0's bundled signing key metadata has expired. Bumped the pinned version to 1.6.6 in `ci.yml` and `dependabot-auto-validation.yml` (verified locally: 1.6.0 fails provider install, 1.6.6 succeeds).
2. **update-terraform-docs** still failing with `Input required and not supplied: token` on Dependabot PRs even after skipping on `github.actor != 'dependabot[bot]'`, because branch updates via the API don't necessarily set `github.actor` to dependabot. Changed the condition to check `github.event.pull_request.user.login` instead, which reflects the actual PR author.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>